### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,10 @@
   "keywords": ["NLP"],
   "author": "Hideaki Ohno <hide.o.j55@gmail.com>",
   "dependencies": {
-    "node-gyp": ""
   },
   "devDependencies": {},
   "main": "./index.js",
   "engines": {
     "node": ">=0.6.x"
-  },
-  "scripts": {
-    "install": "node-gyp rebuild"
   }
 }


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore.
