### PR TITLE
Add NodeJS version of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ node_js:
   - "0.10"
   - "0.12"
   - "4.0"
+  - "6.0"
   - "6.14"
+  - "8.0"
   - "8.11"
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.10"
   - "0.12"
   - "4.0"
+  - "6.14"
   - "8.11"
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Since NodeJS 6.0, 6.14, and 8.0 are now supported by NodeJS official, I added these version to the version of NodeJS used in Travis CI (See [nodejs/Release: Node.js Foundation Release Working Group](https://github.com/nodejs/Release)).